### PR TITLE
propagate return values

### DIFF
--- a/src/ssl/ssl_io.c
+++ b/src/ssl/ssl_io.c
@@ -121,11 +121,9 @@ run_until(br_sslio_context *ctx, unsigned target)
 
 			buf = br_ssl_engine_recvrec_buf(ctx->engine, &len);
 			rlen = ctx->low_read(ctx->read_context, buf, len);
-			if (rlen == -ERESTARTSYS)
+			if (rlen <= 0) {
+				// br_ssl_engine_fail(ctx->engine, BR_ERR_IO);
 				return rlen;
-			if (rlen < 0) {
-				br_ssl_engine_fail(ctx->engine, BR_ERR_IO);
-				return -1;
 			}
 			if (rlen > 0) {
 				br_ssl_engine_recvrec_ack(ctx->engine, rlen);


### PR DESCRIPTION
To allow proper IO error handling in the upper levels.