### PR TITLE
chore: Export additional symbols for SSL engine functionality

### DIFF
--- a/src/linuxkm.c
+++ b/src/linuxkm.c
@@ -2,20 +2,19 @@
 #include "inner.h"
 
 EXPORT_SYMBOL(br_ssl_server_init_full_rsa);
+EXPORT_SYMBOL(br_ssl_server_reset);
 EXPORT_SYMBOL(br_ssl_server_init_full_ec);
 EXPORT_SYMBOL(br_ssl_client_init_full);
-EXPORT_SYMBOL(br_ssl_engine_set_buffer);
-EXPORT_SYMBOL(br_ssl_server_reset);
 EXPORT_SYMBOL(br_ssl_client_reset);
-EXPORT_SYMBOL(br_ssl_engine_recvapp_buf);
-EXPORT_SYMBOL(br_ssl_engine_recvapp_ack);
+EXPORT_SYMBOL(br_ssl_engine_set_buffer);
+EXPORT_SYMBOL(br_ssl_engine_flush);
+EXPORT_SYMBOL(br_ssl_engine_close);
+EXPORT_SYMBOL(br_ssl_client_set_single_rsa);
 EXPORT_SYMBOL(br_sslio_init);
 EXPORT_SYMBOL(br_sslio_read);
 EXPORT_SYMBOL(br_sslio_write_all);
 EXPORT_SYMBOL(br_sslio_flush);
 EXPORT_SYMBOL(br_sslio_close);
-EXPORT_SYMBOL(br_ssl_engine_close);
-EXPORT_SYMBOL(br_ssl_client_set_single_rsa);
 EXPORT_SYMBOL(br_rsa_pkcs1_sign_get_default);
 EXPORT_SYMBOL(br_x509_minimal_init_full);
 EXPORT_SYMBOL(br_ssl_engine_set_default_rsavrfy);
@@ -30,6 +29,14 @@ EXPORT_SYMBOL(br_x509_decoder_push);
 EXPORT_SYMBOL(br_ssl_engine_set_suites);
 EXPORT_SYMBOL(br_sslrec_out_clear_vtable);
 EXPORT_SYMBOL(br_ssl_engine_current_state);
+EXPORT_SYMBOL(br_ssl_engine_recvrec_buf);
+EXPORT_SYMBOL(br_ssl_engine_recvrec_ack);
+EXPORT_SYMBOL(br_ssl_engine_sendrec_buf);
+EXPORT_SYMBOL(br_ssl_engine_sendrec_ack);
+EXPORT_SYMBOL(br_ssl_engine_recvapp_buf);
+EXPORT_SYMBOL(br_ssl_engine_recvapp_ack);
+EXPORT_SYMBOL(br_ssl_engine_sendapp_buf);
+EXPORT_SYMBOL(br_ssl_engine_sendapp_ack);
 
 static int __init bearssl_init(void)
 {


### PR DESCRIPTION
these functions are needed when using the low-level API