### PR TITLE
fix: add MIN and MAX macros if not defined; remove unused EXPORT_SYMBOL

### DIFF
--- a/src/inner.h
+++ b/src/inner.h
@@ -924,7 +924,8 @@ BIT_LENGTH(uint32_t x)
 	k += GT(x, 0x0001);
 	return k;
 }
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
+
+#ifndef MIN
 /*
  * Compute the minimum of x and y.
  */
@@ -933,7 +934,9 @@ MIN(uint32_t x, uint32_t y)
 {
 	return MUX(GT(x, y), y, x);
 }
+#endif
 
+#ifndef MAX
 /*
  * Compute the maximum of x and y.
  */
@@ -943,6 +946,7 @@ MAX(uint32_t x, uint32_t y)
 	return MUX(GT(x, y), x, y);
 }
 #endif
+
 /*
  * Multiply two 32-bit integers, with a 64-bit result. This default
  * implementation assumes that the basic multiplication operator

--- a/src/linuxkm.c
+++ b/src/linuxkm.c
@@ -27,7 +27,6 @@ EXPORT_SYMBOL(br_prng_seeder_system);
 EXPORT_SYMBOL(br_x509_decoder_init);
 EXPORT_SYMBOL(br_x509_decoder_push);
 EXPORT_SYMBOL(br_ssl_engine_set_suites);
-EXPORT_SYMBOL(br_sslrec_out_clear_vtable);
 EXPORT_SYMBOL(br_ssl_engine_current_state);
 EXPORT_SYMBOL(br_ssl_engine_recvrec_buf);
 EXPORT_SYMBOL(br_ssl_engine_recvrec_ack);
@@ -63,3 +62,4 @@ module_init(bearssl_init);
 module_exit(bearssl_exit);
 
 MODULE_LICENSE("Dual MIT/GPL");
+MODULE_AUTHOR("Riptides Labs, Inc <tech@riptides.io>");


### PR DESCRIPTION
this fixes compile on 5.14/15 RHEL based kernels